### PR TITLE
Allow use of host SSH agent.

### DIFF
--- a/io.atom.Atom.json
+++ b/io.atom.Atom.json
@@ -13,6 +13,7 @@
   "finish-args": [
       "--share=ipc", "--socket=x11",
       "--socket=pulseaudio",
+      "--socket=ssh-auth",
       "--share=network",
       "--device=all",
       "--filesystem=host",


### PR DESCRIPTION
This PR adds support for using the host's SSH agent, which is very useful when interacting with git repositories, which in turn is very common when using Atom.