### PR TITLE
Add TMPDIR environment variable

### DIFF
--- a/io.atom.Atom.json
+++ b/io.atom.Atom.json
@@ -23,6 +23,7 @@
       "--talk-name=org.gtk.vfs",
       "--talk-name=org.gtk.vfs.*",
       "--env=ELECTRON_TRASH=this-is-a-workaround",
+      "--env=TMPDIR=/var/tmp",
       "--filesystem=xdg-config/kdeglobals:ro",
       "--talk-name=com.canonical.AppMenu.Registrar",
       "--talk-name=com.canonical.AppMenu.Registrar.*"


### PR DESCRIPTION
In order to fix the problem of multiple instances when calling the
flatpak run command for same directory[1] multiple times, this patch
changes the tmp-dir that electron uses to write the single instance
lock to.

This fix was adviced in the electron base app[2] and also approved by
the electron project[3].

[1]: Like: `flatpak run io.atom.io.atom.Atom somedir`
[2]: https://github.com/flathub/org.electronjs.Electron2.BaseApp/issues/4
[3]: https://github.com/electron/electron/issues/15304