### PR TITLE
Make extensions actually usable

### DIFF
--- a/io.atom.Atom.json
+++ b/io.atom.Atom.json
@@ -57,7 +57,9 @@
 
         "install -Dm644 io.atom.Atom.appdata.xml /app/share/appdata/io.atom.Atom.appdata.xml",
 
-        "install pip3 /app/bin"
+        "install pip3 /app/bin",
+        
+        "mkdir -p /app/extensions"
       ],
       "cleanup": [
         "/share/lintian",


### PR DESCRIPTION
Currently the app has an extension point, but directory for it doesn't exist.