### PR TITLE
Revert "Update to 1.54.0"

### DIFF
--- a/io.atom.Atom.appdata.xml
+++ b/io.atom.Atom.appdata.xml
@@ -19,7 +19,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.54.0" date="2021-01-13"/>
+    <release version="1.51.0" date="2020-09-09"/>
   </releases>
   <kudos>
     <kudo>HiDpiIcon</kudo>

--- a/io.atom.Atom.json
+++ b/io.atom.Atom.json
@@ -68,8 +68,8 @@
       "sources": [
         {
           "type": "file",
-          "url": "https://atom-installer.github.com/v1.54.0/atom-amd64.deb",
-          "sha256": "db5014460a26123ba24f3789e0c231d26932562d1bd2655d985b0518d2d744fe"
+          "url": "https://atom-installer.github.com/v1.51.0/atom-amd64.deb",
+          "sha256": "ea1517f928916e09108fc1a0e6942304fcaa0dc9a920e0eb2de45d128dc1f331"
         },
         {
           "type": "file",


### PR DESCRIPTION
Reverts flathub/io.atom.Atom#87

This update broke atom, I don't have time to look into it right now.