### PR TITLE
Mark as EOL; rebase to Pulsar

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,5 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "end-of-life": "Atom has been sunset; Pulsar (dev.pulsar_edit.Pulsar) is a maintained community fork.",
+  "end-of-life-rebase": "dev.pulsar_edit.Pulsar"
 }


### PR DESCRIPTION
https://github.blog/2022-06-08-sunsetting-atom/
https://pulsar-edit.dev/about.html

The currently-published version shows this tab when it is launched:

![Screenshot from 2023-11-17 17-12-28](https://github.com/flathub/io.atom.Atom/assets/86760/ef3c45ba-1c83-4fcb-9c1a-39b22807d50c)

I don't actually know if Pulsar is a drop-in replacement, but in my opinion the alternative is to mark this app as EOL with no replacement.